### PR TITLE
Add support for editing items

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "ds-rom",
  "rstest",
  "serde",
+ "serde-big-array",
  "serde_json",
  "serde_norway",
  "tauri",
@@ -3386,6 +3387,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_norway = "0.9"
+serde-big-array = "0.5"
 ds-rom = "0.7"
 binrw = "0.15"
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,11 +11,15 @@ use ds_rom::rom::{raw, Rom, RomLoadOptions};
 use tauri::Manager;
 
 use crate::dqmj1_rom::{
-    btl_enmy_prm::BtlEnmyPrm, regions::Region, skill_tbl::SkillTblWithRegion,
-    string_tables::StringTables,
+    btl_enmy_prm::BtlEnmyPrm, item_tbl::ItemTblWithRegion, regions::Region,
+    skill_tbl::SkillTblWithRegion, string_tables::StringTables,
 };
 
-const MOD_FILES: [&str; 2] = ["files/BtlEnmyPrm.bin", "files/SkillTbl.bin"];
+const MOD_FILES: [&str; 3] = [
+    "files/BtlEnmyPrm.bin",
+    "files/ItemTbl.bin",
+    "files/SkillTbl.bin",
+];
 
 fn get_app_directory(app: &tauri::AppHandle) -> PathBuf {
     let app_directory = app.path().app_data_dir().unwrap();
@@ -142,6 +146,18 @@ pub fn set_skill_tbl(app: tauri::AppHandle, skill_tbl: SkillTblWithRegion) {
         SkillTblWithRegion::Na(skill_tbl) => file.write_le(&skill_tbl).unwrap(),
         SkillTblWithRegion::Jp(skill_tbl) => file.write_le(&skill_tbl).unwrap(),
     };
+}
+
+#[tauri::command]
+pub fn get_item_tbl(app: tauri::AppHandle) -> ItemTblWithRegion {
+    let temp_directory = get_temp_directory(&app);
+    let region = get_region(&temp_directory);
+
+    let filepath = temp_directory.join("files").join("ItemTbl.bin");
+    println!("Reading ItemTbl from: {filepath:?}");
+    let file_data = fs::read(filepath).unwrap();
+
+    ItemTblWithRegion::read(&file_data, region).unwrap()
 }
 
 #[tauri::command]

--- a/src-tauri/src/dqmj1_rom/item_tbl/jp.rs
+++ b/src-tauri/src/dqmj1_rom/item_tbl/jp.rs
@@ -1,0 +1,33 @@
+use binrw::binrw;
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+
+#[binrw]
+#[brw(little)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Item {
+    category: u8, // 0=?, 1=?, 2+ = equipment?
+    unknown_ab: [u8; 7],
+    unknown_b: u8,
+    weapon_type: u8, // 0 through 6
+    unknown_c: [u8; 16],
+    attack_increase: u8,
+    defense_increase: u8,
+    agility_increase: u8,
+    wisdom_increase: u8,
+    max_hp_increase: u8,
+    max_mp_increase: u8,
+    #[serde(with = "BigArray")]
+    unknown: [u8; 36],
+}
+
+#[binrw]
+#[brw(little)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ItemTbl {
+    pub magic: u32, // TODO: use magic= field in brw instead
+    pub length: u32,
+
+    #[br(count = length)]
+    pub entries: Vec<Item>,
+}

--- a/src-tauri/src/dqmj1_rom/item_tbl/mod.rs
+++ b/src-tauri/src/dqmj1_rom/item_tbl/mod.rs
@@ -1,0 +1,26 @@
+use std::io::Cursor;
+
+use binrw::{BinRead, BinResult};
+use serde::{Deserialize, Serialize};
+
+use crate::dqmj1_rom::regions::Region;
+
+pub mod jp;
+pub mod na;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum ItemTblWithRegion {
+    Jp(jp::ItemTbl),
+    Na(na::ItemTbl),
+}
+
+impl ItemTblWithRegion {
+    pub fn read(file_data: &[u8], region: Region) -> BinResult<Self> {
+        let mut reader = Cursor::new(file_data);
+        match region {
+            Region::NorthAmerica => na::ItemTbl::read(&mut reader).map(ItemTblWithRegion::Na),
+            Region::Japan => jp::ItemTbl::read(&mut reader).map(ItemTblWithRegion::Jp),
+            Region::Europe => panic!("Europe not yet supported for ItemTbl parsing"),
+        }
+    }
+}

--- a/src-tauri/src/dqmj1_rom/item_tbl/na.rs
+++ b/src-tauri/src/dqmj1_rom/item_tbl/na.rs
@@ -6,13 +6,13 @@ use serde_big_array::BigArray;
 #[brw(little)]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Item {
-    category: u8, // 0=?, 1=?, 2+ = equipment?
+    category: u8, // 0=usable item, 1=key item, 2+ = equipment?
     unknown_ab: [u8; 3],
-    restore_stat: u8,
-    can_revive: u8,
+    effect: u8, // 1=restore hp, 2=restore mp, 3=revive, 4=cure poison, 5=cure paralysis, 6=cure all status effects, ...
+    unknown_abb: u8,
     restore_min: u8,
     restore_max: u8,
-    unknown_b: u8,
+    subcategory: u8,
     weapon_type: u8, // 0 through 6
     unknown_c: [u8; 6],
     buy_value: u32,

--- a/src-tauri/src/dqmj1_rom/item_tbl/na.rs
+++ b/src-tauri/src/dqmj1_rom/item_tbl/na.rs
@@ -1,0 +1,40 @@
+use binrw::binrw;
+use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
+
+#[binrw]
+#[brw(little)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Item {
+    category: u8, // 0=?, 1=?, 2+ = equipment?
+    unknown_ab: [u8; 3],
+    restore_stat: u8,
+    can_revive: u8,
+    restore_min: u8,
+    restore_max: u8,
+    unknown_b: u8,
+    weapon_type: u8, // 0 through 6
+    unknown_c: [u8; 6],
+    buy_value: u32,
+    sell_value: u32,
+    unknown_d: [u8; 2],
+    attack_increase: u8,
+    defense_increase: u8,
+    agility_increase: u8,
+    wisdom_increase: u8,
+    max_hp_increase: u8,
+    max_mp_increase: u8,
+    #[serde(with = "BigArray")]
+    unknown: [u8; 76],
+}
+
+#[binrw]
+#[brw(little)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ItemTbl {
+    pub magic: u32, // TODO: use magic= field in brw instead
+    pub length: u32,
+
+    #[br(count = length)]
+    pub entries: Vec<Item>,
+}

--- a/src-tauri/src/dqmj1_rom/item_tbl/na.rs
+++ b/src-tauri/src/dqmj1_rom/item_tbl/na.rs
@@ -24,8 +24,10 @@ pub struct Item {
     wisdom_increase: u8,
     max_hp_increase: u8,
     max_mp_increase: u8,
+    unknown_e: [u8; 12],
+    item_id: u8,
     #[serde(with = "BigArray")]
-    unknown: [u8; 76],
+    unknown: [u8; 63],
 }
 
 #[binrw]

--- a/src-tauri/src/dqmj1_rom/mod.rs
+++ b/src-tauri/src/dqmj1_rom/mod.rs
@@ -1,4 +1,5 @@
 pub mod btl_enmy_prm;
+pub mod item_tbl;
 pub mod regions;
 pub mod skill_tbl;
 pub mod string_tables;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::commands::{
-    create_mod, get_btl_enmy_prm, get_mods, get_skill_tbl, get_string_tables, load_mod, pack_rom,
-    save_mod, set_btl_enmy_prm, set_skill_tbl, unpack_rom,
+    create_mod, get_btl_enmy_prm, get_item_tbl, get_mods, get_skill_tbl, get_string_tables,
+    load_mod, pack_rom, save_mod, set_btl_enmy_prm, set_skill_tbl, unpack_rom,
 };
 
 pub mod commands;
@@ -21,6 +21,7 @@ pub fn run() {
             get_mods,
             get_btl_enmy_prm,
             set_btl_enmy_prm,
+            get_item_tbl,
             get_skill_tbl,
             set_skill_tbl,
             get_string_tables

--- a/src/editor.html
+++ b/src/editor.html
@@ -19,6 +19,7 @@
         <ul>
           <li id="navigation-encounters">Encounters</li>
           <li id="navigation-skill-sets">Skill sets</li>
+          <li id="navigation-items">Items</li>
         </ul>
       </div>
       <div class="column">
@@ -601,6 +602,36 @@
                     </td>
                     <td>
                       <select id="skill-sets-trait-10-4"></select>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </div>
+        <!-- Items -->
+        <div id="items-page" class="page">
+          <select id="items-select"></select>
+          <hr />
+
+          <table class="page-table">
+            <tr>
+              <td>
+                <table>
+                  <tr>
+                    <th>Item</th>
+                    <td id="items-item-id"></td>
+                  </tr>
+                  <tr>
+                    <th>Category</th>
+                    <td>
+                      <select id="items-category"></select>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Effect</th>
+                    <td>
+                      <select id="items-effect"></select>
                     </td>
                   </tr>
                 </table>

--- a/src/editor.html
+++ b/src/editor.html
@@ -624,14 +624,77 @@
                   </tr>
                   <tr>
                     <th>Category</th>
-                    <td>
+                    <td colspan="2">
                       <select id="items-category"></select>
                     </td>
                   </tr>
                   <tr>
+                    <th>Subcategory</th>
+                    <td colspan="2">
+                      <select id="items-subcategory"></select>
+                    </td>
+                  </tr>
+                  <tr>
                     <th>Effect</th>
-                    <td>
+                    <td colspan="2">
                       <select id="items-effect"></select>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Buy</th>
+                    <td>
+                      <input id="items-buy" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Sell</th>
+                    <td>
+                      <input id="items-sell" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Restore</th>
+                    <td>
+                      <input id="items-restore-min" />
+                    </td>
+                    <td>
+                      <input id="items-restore-max" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Max HP</th>
+                    <td>
+                      <input id="items-max-hp" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Max MP</th>
+                    <td>
+                      <input id="items-max-mp" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Attack</th>
+                    <td>
+                      <input id="items-attack" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Defense</th>
+                    <td>
+                      <input id="items-defense" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Agility</th>
+                    <td>
+                      <input id="items-agility" />
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Wisdom</th>
+                    <td>
+                      <input id="items-wisdom" />
                     </td>
                   </tr>
                 </table>

--- a/src/editor.js
+++ b/src/editor.js
@@ -441,11 +441,23 @@ function showItem(itemId) {
 
     document.getElementById("items-item-id").innerHTML = itemId;
     document.getElementById("items-category").value = item.category;
+    document.getElementById("items-subcategory").value = item.subcategory;
     document.getElementById("items-effect").value = item.effect;
+    document.getElementById("items-buy").value = item.buy_value;
+    document.getElementById("items-sell").value = item.sell_value;
+    document.getElementById("items-restore-min").value = item.restore_min;
+    document.getElementById("items-restore-max").value = item.restore_max;
+    document.getElementById("items-max-hp").value = item.max_hp_increase;
+    document.getElementById("items-max-mp").value = item.max_mp_increase;
+    document.getElementById("items-attack").value = item.attack_increase;
+    document.getElementById("items-defense").value = item.defense_increase;
+    document.getElementById("items-agility").value = item.agility_increase;
+    document.getElementById("items-wisdom").value = item.wisdom_increase;
 }
 
 function setupItems() {
     setupItemCategories();
+    setupItemSubcategories();
     setupItemEffects();
 }
 
@@ -454,7 +466,7 @@ function setupItemCategories() {
 
     const options = [
         [0, "Usable item"],
-        [1, "Key item"],
+        [1, "Non-usable item"],
         [2, "Sword"],
         [3, "Spear"],
         [4, "Axe"],
@@ -471,6 +483,28 @@ function setupItemCategories() {
     categorySelect.innerHTML = innerHTML.join("");
 }
 
+function setupItemSubcategories() {
+    const subcategorySelect = document.getElementById("items-subcategory");
+
+    const options = [
+        [0, "Cure status"],
+        [1, "Heal ally"],
+        //  2 = ???
+        [3, "Buff ally"],
+        [4, "Debuff enemy"],
+        [5, "Increase stat"],
+        //  6 = ???
+        [7, "Equipment"],
+        [8, "Key item"],
+    ];
+
+    const innerHTML = [];
+    for (const [num, description] of options) {
+        innerHTML.push(`<option value="${num}">${description} (${num})</option>`);
+    }
+    subcategorySelect.innerHTML = innerHTML.join("");
+}
+
 function setupItemEffects() {
     const effectSelect = document.getElementById("items-effect");
 
@@ -482,10 +516,10 @@ function setupItemEffects() {
         [4, "Cure poison"],
         [5, "Cure paralysis"],
         [6, "Cure all status effects"],
-        [7, "Seal enemy magic"],
-        [8, "Increase ally attack"],
-        [9, "Increase ally magic resistance"],
-        [10, "Increase ally breath resistance"],
+        [7, "Seal magic"],
+        [8, "Increase attack temporarily"],
+        [9, "Increase magic resistance"],
+        [10, "Increase breath resistance"],
         // 11 = ???
         [12, "Increase skill points"],
         [13, "Increase max HP"],

--- a/src/editor.js
+++ b/src/editor.js
@@ -13,6 +13,7 @@ let stringTables = null;
 
 let currentEncounterId = 48; // starter Dracky
 let currentSkillSetId = 58; // Dark Knight
+let currentItemId = 1; // medicinal herb
 let currentPage = null;
 let currentPageNavigation = null;
 
@@ -23,6 +24,7 @@ async function setupPages() {
 
     setupEncounters();
     setupSkillSets();
+    setupItems();
 }
 
 function setupEncounters() {
@@ -399,6 +401,117 @@ function populateTraitForSkillSet(i, j) {
     trait.value = skillSets.entries[currentSkillSetId].traits[i - 1].trait_ids[j - 1];
 }
 
+async function showItems() {
+    console.log("Showing items");
+
+    currentPage = document.getElementById("items-page");
+    currentPageNavigation = document.getElementById("navigation-items");
+
+    currentPage.style.display = "block";
+    currentPageNavigation.classList = "selected";
+
+    await getItems();
+    await getStringTables();
+
+    const select = document.getElementById("items-select");
+    select.innerHTML = "";
+
+    console.log(items);
+
+    let i = 0;
+    for (const _item of items.entries) {
+        const option = document.createElement("option");
+        select.appendChild(option);
+
+        option.text = `${stringTables.item_names[i]} (${padToDigits(i, 3)})`;
+        option.value = i;
+
+        i++;
+    }
+
+    select.value = currentItemId;
+    showItem(currentItemId);
+}
+
+function showItem(itemId) {
+    const item = items.entries[itemId];
+    console.log(item);
+
+    currentItemId = itemId;
+
+    document.getElementById("items-item-id").innerHTML = itemId;
+    document.getElementById("items-category").value = item.category;
+    document.getElementById("items-effect").value = item.effect;
+}
+
+function setupItems() {
+    setupItemCategories();
+    setupItemEffects();
+}
+
+function setupItemCategories() {
+    const categorySelect = document.getElementById("items-category");
+
+    const options = [
+        [0, "Usable item"],
+        [1, "Key item"],
+        [2, "Sword"],
+        [3, "Spear"],
+        [4, "Axe"],
+        [5, "Hammer"],
+        [6, "Whip"],
+        [7, "Claws"],
+        [8, "Staff"],
+    ];
+
+    const innerHTML = [];
+    for (const [num, description] of options) {
+        innerHTML.push(`<option value="${num}">${description} (${num})</option>`);
+    }
+    categorySelect.innerHTML = innerHTML.join("");
+}
+
+function setupItemEffects() {
+    const effectSelect = document.getElementById("items-effect");
+
+    const options = [
+        [0, "Unknown"], // likely just dummy default value
+        [1, "Restore HP"],
+        [2, "Restore MP"],
+        [3, "Revive ally"],
+        [4, "Cure poison"],
+        [5, "Cure paralysis"],
+        [6, "Cure all status effects"],
+        [7, "Seal enemy magic"],
+        [8, "Increase ally attack"],
+        [9, "Increase ally magic resistance"],
+        [10, "Increase ally breath resistance"],
+        // 11 = ???
+        [12, "Increase skill points"],
+        [13, "Increase max HP"],
+        [14, "Increase max MP"],
+        [15, "Increase attack"],
+        [16, "Increase defense"],
+        [17, "Increase agility"],
+        [18, "Increase wisdom"],
+        [19, "Teleport to scoutpost"],
+        [20, "Teleport out of dungeon"],
+        [21, "Discount gold purchases"],
+        [22, "None"],
+        [23, "Equipment"],
+        [24, "Guarantee next battle polarity"],
+        [25, "Key item with impact"],
+        [26, "Skill set book"],
+        [27, "Player skill book"],
+    ];
+
+    const innerHTML = [];
+    for (const [num, description] of options) {
+        innerHTML.push(`<option value="${num}">${description} (${num})</option>`);
+    }
+    effectSelect.innerHTML = innerHTML.join("");
+}
+
 async function getSkillSets() {
     if (skillSets === null) {
         const options = {};
@@ -499,6 +612,8 @@ async function showPage(pageName) {
         showEncounters();
     } else if (pageName === "skill-sets") {
         showSkillSets();
+    } else if (pageName === "items") {
+        showItems();
     }
 }
 
@@ -516,6 +631,12 @@ window.addEventListener("DOMContentLoaded", () => {
         e.preventDefault();
 
         showPage("skill-sets");
+    });
+
+    document.querySelector("#navigation-items").addEventListener("click", (e) => {
+        e.preventDefault();
+
+        showPage("items");
     });
 
     document.querySelector("#encounters-select").addEventListener("change", (e) => {
@@ -540,6 +661,18 @@ window.addEventListener("DOMContentLoaded", () => {
 
         const id = parseInt(value.substring(0, 3));
         showSkillSet(id);
+    });
+
+    document.querySelector("#items-select").addEventListener("change", (e) => {
+        e.preventDefault();
+
+        const select = document.getElementById("items-select");
+        const value = select.value;
+
+        console.log(value);
+
+        const id = parseInt(value.substring(0, 3));
+        showItem(id);
     });
 
     document.querySelector("#save-mod").addEventListener("click", (e) => {

--- a/src/editor.js
+++ b/src/editor.js
@@ -7,6 +7,8 @@ const modName = url.searchParams.get("modName");
 let encounters = null;
 let skillSets = null;
 let skillSetsRegion = null;
+let items = null;
+let itemsRegion = null;
 let stringTables = null;
 
 let currentEncounterId = 48; // starter Dracky
@@ -16,6 +18,8 @@ let currentPageNavigation = null;
 
 async function setupPages() {
     await getStringTables();
+
+    await getItems();
 
     setupEncounters();
     setupSkillSets();
@@ -408,6 +412,22 @@ async function getSkillSets() {
 
         console.log(skillSetsRegion);
         console.log(skillSets);
+    }
+}
+
+async function getItems() {
+    if (items === null) {
+        const options = {};
+        console.log(`Getting items: ${JSON.stringify(options)}`);
+        const response = await invoke("get_item_tbl", options);
+
+        for (const [region, data] of Object.entries(response)) {
+            itemsRegion = region;
+            items = data;
+        }
+
+        console.log(itemsRegion);
+        console.log(items);
     }
 }
 


### PR DESCRIPTION
## Notes
Some item behaviors are hard-coded into the game's executables, and thus cannot be edited:

* Weapon effectiveness against specific monster families (ex. +50% damage against demons)
* Phoenix, plus, and minus scepter effects when synthesizing

## Checklist
* [ ] Update changelog