### PR TITLE
Fix some panics in the string encoding code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * LoadSkeletalAnimation (#20)
 * Added support for line comments in event scripts (#21)
 
+### Fixed
+* Fixed program crashing when loading an event script the includes a character that does not have a known mapping into a DQMJ1 String. (#16, #18)
+
 ## [0.4.0] - 2026-05-02
 
 ### Added

--- a/dqmj1_rom_util/fuzz/Cargo.toml
+++ b/dqmj1_rom_util/fuzz/Cargo.toml
@@ -27,3 +27,9 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "string_encoding"
+path = "fuzz_targets/string_encoding.rs"
+test = false
+doc = false
+bench = false

--- a/dqmj1_rom_util/fuzz/fuzz_targets/string_encoding.rs
+++ b/dqmj1_rom_util/fuzz/fuzz_targets/string_encoding.rs
@@ -1,0 +1,12 @@
+#![no_main]
+
+use dqmj1_rom_util::{regions::Region, strings::encoding::CharacterEncoding};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|string: &str| {
+    let na = CharacterEncoding::get(Region::NorthAmerica);
+    let jp = CharacterEncoding::get(Region::Japan);
+
+    na.encode_string(string);
+    jp.encode_string(string);
+});

--- a/dqmj1_rom_util/src/events/disassembly.rs
+++ b/dqmj1_rom_util/src/events/disassembly.rs
@@ -850,7 +850,7 @@ mod tests {
         let character_encoding = CharacterEncoding::get(Region::NorthAmerica);
 
         let decoded = DisassembledEvt::from_evt(&evt, &character_encoding, &opcodes);
-        let encoded = decoded.to_evt(&character_encoding);
+        let encoded = decoded.to_evt(&character_encoding).unwrap();
 
         assert_eq!(encoded.data, evt.data);
         assert_eq!(encoded.instructions, evt.instructions);

--- a/dqmj1_rom_util/src/events/disassembly.rs
+++ b/dqmj1_rom_util/src/events/disassembly.rs
@@ -139,7 +139,10 @@ impl DecodedInstruction<'_> {
         }
     }
 
-    pub fn get_raw_size_bytes(&self, character_encoding: &CharacterEncoding) -> usize {
+    pub fn get_raw_size_bytes(
+        &self,
+        character_encoding: &CharacterEncoding,
+    ) -> Result<usize, String> {
         let header_size = 8; // opcode + length
 
         let mut args_size = 0;
@@ -152,7 +155,7 @@ impl DecodedInstruction<'_> {
                 Arg::StringLit(string) => match arg_kind {
                     ArgumentKind::AsciiString => Self::round_up_to_multiple_of_4(string.len() + 1), // characters + null terminator
                     ArgumentKind::Dqmj1String => {
-                        let encoded_string = character_encoding.encode_string(string);
+                        let encoded_string = character_encoding.encode_string(string)?;
                         Self::round_up_to_multiple_of_4(encoded_string.len())
                     }
                     ArgumentKind::ShiftJisString => {
@@ -166,7 +169,7 @@ impl DecodedInstruction<'_> {
 
         assert_eq!(args_size % 4, 0);
 
-        header_size + args_size
+        Ok(header_size + args_size)
     }
 
     fn round_up_to_multiple_of_4(value: usize) -> usize {
@@ -239,7 +242,7 @@ impl DisassembledEvt<'_> {
         }
     }
 
-    pub fn to_evt(&self, character_encoding: &CharacterEncoding) -> Evt {
+    pub fn to_evt(&self, character_encoding: &CharacterEncoding) -> Result<Evt, String> {
         // Find byte offsets for each label
         let mut i = 0;
         let mut label_to_offset = BTreeMap::new();
@@ -248,7 +251,7 @@ impl DisassembledEvt<'_> {
                 label_to_offset.insert(label.clone(), i);
             }
 
-            let size = instruction.get_raw_size_bytes(character_encoding);
+            let size = instruction.get_raw_size_bytes(character_encoding)?;
             i += size;
         }
 
@@ -277,7 +280,9 @@ impl DisassembledEvt<'_> {
                                 bytes.push(0x00);
                                 bytes
                             } // characters + null terminator
-                            ArgumentKind::Dqmj1String => character_encoding.encode_string(string),
+                            ArgumentKind::Dqmj1String => {
+                                character_encoding.encode_string(string)?
+                            }
                             ArgumentKind::ShiftJisString => {
                                 let (encoded_string, _, _) = SHIFT_JIS.encode(string);
                                 let mut encoded_string = encoded_string.to_vec();
@@ -298,7 +303,7 @@ impl DisassembledEvt<'_> {
                 };
             }
 
-            let size = instruction.get_raw_size_bytes(character_encoding);
+            let size = instruction.get_raw_size_bytes(character_encoding)?;
             instructions.push(RawInstruction {
                 opcode: instruction.opcode.id as u32,
                 length: size as u32,
@@ -306,11 +311,11 @@ impl DisassembledEvt<'_> {
             });
         }
 
-        Evt {
+        Ok(Evt {
             magic: EVT_MAGIC,
             data: self.data,
             instructions,
-        }
+        })
     }
 
     fn parse_arguments(

--- a/dqmj1_rom_util/src/strings/encoding.rs
+++ b/dqmj1_rom_util/src/strings/encoding.rs
@@ -33,17 +33,25 @@ impl CharacterEncoding {
         }
     }
 
-    pub fn encode_string(&self, string: &str) -> Vec<u8> {
+    pub fn encode_string(&self, string: &str) -> Result<Vec<u8>, String> {
         let mut string_bytes: Vec<u8> = vec![];
         let mut hex_buffer: Vec<char> = vec![];
         let mut escape_buffer: Vec<char> = vec![];
         for char in string.chars() {
             let mut chars = vec![];
             if char == ']' {
+                if hex_buffer.len() < 3 {
+                    return Err("Found closing ] too early".to_string());
+                }
+
                 let char_bytes: String = hex_buffer[3..].iter().cloned().collect();
-                string_bytes.push(u8::from_str_radix(&char_bytes, 16).unwrap());
-                hex_buffer.clear();
-                continue;
+                if let Ok(hex_value) = u8::from_str_radix(&char_bytes, 16) {
+                    string_bytes.push(hex_value);
+                    hex_buffer.clear();
+                    continue;
+                } else {
+                    return Err(format!("Invalid hex value: \"{}\"", char_bytes));
+                }
             } else if char == '[' || !hex_buffer.is_empty() {
                 hex_buffer.push(char);
                 continue;
@@ -60,8 +68,7 @@ impl CharacterEncoding {
             }
 
             if !self.char_to_byte_map.contains_key(&chars) {
-                println!("Unrecognized chars: {:?}", chars);
-                panic!();
+                return Err(format!("Unrecognized chars: {:?}", chars));
             }
 
             let mut matching_bytes: Vec<u8> = self.char_to_byte_map[&chars].clone();
@@ -70,7 +77,7 @@ impl CharacterEncoding {
 
         string_bytes.push(0xFF);
 
-        string_bytes
+        Ok(string_bytes)
     }
 
     pub fn read_string(&self, bytes: &[u8]) -> String {
@@ -176,6 +183,6 @@ mod tests {
     fn encode_string(#[case] region: Region, #[case] string: &str, #[case] expected: &[u8]) {
         let encoding = CharacterEncoding::get(region);
 
-        assert_eq!(encoding.encode_string(string), expected);
+        assert_eq!(encoding.encode_string(string).unwrap(), expected);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -17,7 +17,7 @@ use tauri::Manager;
 use dqmj1_rom_util::{
     btl_enmy_prm::BtlEnmyPrm,
     events::{
-        assembly::parser::{parse_dqmj1_asm, ParseLexErrors},
+        assembly::parser::{parse_dqmj1_asm, ParseError, ParseLexError, ParseLexErrors},
         binary::Evt,
         disassembly::{DisassembledEvt, Opcode},
     },
@@ -259,7 +259,9 @@ fn assemble_event_asm_file(
 
     let contents = std::fs::read_to_string(asm_filepath).unwrap();
     let disassembled = parse_dqmj1_asm(&contents, opcodes)?;
-    let evt = disassembled.to_evt(character_encoding);
+    let evt = disassembled
+        .to_evt(character_encoding)
+        .map_err(|err| vec![ParseLexError::Parse(ParseError::new(&err))])?;
 
     let mut file = File::create(output_filepath).unwrap();
     evt.write_le(&mut file).unwrap();


### PR DESCRIPTION
Fixes #16

Fix panics that occur when an event script includes a character that does not have a known mapping into a DQMJ1 String.

## Checklist
* [x] Update changelog